### PR TITLE
fix broken internal links in the technology pages

### DIFF
--- a/technology/discovery.md
+++ b/technology/discovery.md
@@ -1,6 +1,6 @@
 # Discovery
 
-To find servers that support a token pair, clients call the `getURLsForToken` function on the [Registry](https://github.com/airswap/airswap-docs/tree/82d700b725317da365a3680f53106d69db7273bc/technology/deployments/README.md) contract for each token and then intersect the results. For example, if the resulting URLs for token A are `[maker1.com, maker2.com]` and for token B are `[maker2.com, maker3.com]` then the only server supporting swapping token A for B is `maker2.com`.
+To find servers that support a token pair, clients call the `getURLsForToken` function on the [Registry](deployments.md) contract for each token and then intersect the results. For example, if the resulting URLs for token A are `[maker1.com, maker2.com]` and for token B are `[maker2.com, maker3.com]` then the only server supporting swapping token A for B is `maker2.com`.
 
 See `getURLsForToken` on the Registry contract:
 
@@ -8,7 +8,7 @@ See `getURLsForToken` on the Registry contract:
 function getURLsForToken(address token) external view returns (string[] memory urls);
 ```
 
-Check [deployments](https://github.com/airswap/airswap-docs/tree/82d700b725317da365a3680f53106d69db7273bc/technology/deployments/README.md) for latest contract addresses for Registry.
+Check [deployments](deployments.md) for latest contract addresses for Registry.
 
 ## Fetching URLs via CLI
 

--- a/technology/makers.md
+++ b/technology/makers.md
@@ -1,6 +1,6 @@
 # Makers
 
-Makers run web servers that implement the RFQ and Last Look APIs using [JSON-RPC over HTTP](https://www.jsonrpc.org/historical/json-rpc-over-http.html). To be reachable by clients, servers run at public endpoints with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) enabled. To become discoverable, server URLs are added to the [Registry](https://github.com/airswap/airswap-docs/tree/82d700b725317da365a3680f53106d69db7273bc/guides/add-to-the-registry.md) smart contract, which is queried by clients.
+Makers run web servers that implement the RFQ and Last Look APIs using [JSON-RPC over HTTP](https://www.jsonrpc.org/historical/json-rpc-over-http.html). To be reachable by clients, servers run at public endpoints with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) enabled. To become discoverable, server URLs are added to the [Registry](makers.md#adding-to-the-registry) smart contract, which is queried by clients.
 
 ## Introduction
 
@@ -14,7 +14,7 @@ For the RFQ protocol, a server is always the **signer** and the client is always
 
 ## HTTP vs WebSocket
 
-If a URL is HTTPS, it is implied that the server supports the latest RFQ protocol at that endpoint. If a URL is WebSocket \(`wss`\) then the server communicates its supported protocols upon connnection. See the `initialize` method of the [Request for Quote](https://github.com/airswap/airswap-about/tree/0c6694fd69e97125c73962d19b785983484f2f71/technology/request-for-quote/README.md) and [Last Look](https://github.com/airswap/airswap-about/tree/0c6694fd69e97125c73962d19b785983484f2f71/technology/last-look/README.md) protocols for details. WebSocket servers can support both RFQ and Last Look protocols.
+If a URL is HTTPS, it is implied that the server supports the latest RFQ protocol at that endpoint. If a URL is WebSocket \(`wss`\) then the server communicates its supported protocols upon connnection. See the `initialize` method of the [Request for Quote](request-for-quote.md#initialize) and [Last Look](last-look.md#initialize) protocols for details. WebSocket servers can support both RFQ and Last Look protocols.
 
 ## Getting Started
 
@@ -26,7 +26,7 @@ Getting started is as easy as standing up a JSON-RPC web server and adding its U
 
 ## Protocol Fees
 
-When signing orders in RFQ, a protocol fee \(in basis points\) is [hashed into the signature](https://github.com/airswap/airswap-about/tree/0c6694fd69e97125c73962d19b785983484f2f71/technology/signatures/README.md) and verified during settlement. The value of this parameter must match its current value of `signerFee` on the [Light](deployments.md) contract. The amount is transferred from the `signerWallet` address upon settlement.
+When signing orders in RFQ, a protocol fee \(in basis points\) is [hashed into the signature](signatures.md) and verified during settlement. The value of this parameter must match its current value of `signerFee` on the [Light](deployments.md) contract. The amount is transferred from the `signerWallet` address upon settlement.
 
 100% of protocol fees go toward AirSwap governance and development contributors.
 

--- a/technology/request-for-quote.md
+++ b/technology/request-for-quote.md
@@ -138,7 +138,7 @@ curl -H 'Content-Type: application/json' \
      http://localhost:3000/
 ```
 
-After requesting an order, parameters are submitted as an Ethereum transaction to the `swap` function on the [Light](https://docs.airswap.io/contract-deployments) contract, which emits a `Swap` event on success.
+After requesting an order, parameters are submitted as an Ethereum transaction to the `swap` function on the [Light](deployments.md) contract, which emits a `Swap` event on success.
 
 ```typescript
   function swap(

--- a/technology/signatures.md
+++ b/technology/signatures.md
@@ -85,7 +85,7 @@ v, r, s = sign_typed_data(data, bytes.fromhex(SIGNER_KEY))
 
 ## Authorized Signers
 
-**Optional.** One account may authorize another account to sign orders on its behalf. For example, a server might sign using an account that has been authorized by a contract wallet. To manage signer authorizations, use the following functions on the [Light](https://github.com/airswap/airswap-docs/tree/2515c986727706105a3e5ebabb8cfa6df455cbb0/contract-deployments.md) contract.
+**Optional.** One account may authorize another account to sign orders on its behalf. For example, a server might sign using an account that has been authorized by a contract wallet. To manage signer authorizations, use the following functions on the [Light](deployments.md) contract.
 
 ```text
 function authorize(address signer) external
@@ -101,5 +101,5 @@ The following values are used for the EIP712Domain.
 | `name` | `bytes32` | `SWAP_LIGHT` |
 | `version` | `bytes32` | `3` |
 | `chainId` | `uint256` | Ethereum Mainnet: `1`, Rinkeby: `4` |
-| `verifyingContract` | `address` | [Light](https://github.com/airswap/airswap-docs/tree/2515c986727706105a3e5ebabb8cfa6df455cbb0/contract-deployments.md) contract address |
+| `verifyingContract` | `address` | [Light](deployments.md) contract address |
 


### PR DESCRIPTION
This PR fixes a number of broken links on the various technology pages, which were incorrectly linking to a branch that no longer exists.