### PR TITLE
fix remaining broken links and use consistent styling for lists/quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome
 
-[![Discord](https://img.shields.io/discord/590643190281928738.svg)](https://chat.airswap.io) ![Twitter Follow](https://img.shields.io/twitter/follow/airswap?style=social) ![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/AirSwap?style=social) ![GitHub stars](https://img.shields.io/github/stars/airswap/airswap-protocols?style=social)
+[![Discord](https://img.shields.io/discord/590643190281928738.svg)](https://chat.airswap.io) [![Twitter Follow](https://img.shields.io/twitter/follow/airswap?style=social)](https://twitter.com/airswap) [![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/AirSwap?style=social)](https://www.reddit.com/r/AirSwap/) [![GitHub stars](https://img.shields.io/github/stars/airswap/airswap-protocols?style=social)](https://github.com/airswap/airswap-protocols)
 
 [AirSwap](https://www.airswap.io) is an open developer community focused on decentralized trading systems. AirSwap technology powers peer-to-peer networks using de facto standard [RFQ](technology/request-for-quote.md) and [Last Look](technology/last-look.md) protocols making it the top choice for traditional market makers entering the decentralized financial system.
 

--- a/activities/delivery.md
+++ b/activities/delivery.md
@@ -12,18 +12,18 @@ Develop our collective knowledge and expand our presence through high quality en
 
 The scope of the delivery team revolves around three main areas. Contributors are welcome to propose ideas which will grow AirSwap in any of these areas.
 
-* **Awareness** - projects which help to bring awareness to AirSwap
-  * Awareness of the **product** - driving user engagement with the web app
-  * Awareness of the **protocol** - driving new integrations
-  * Awareness of our **community** - welcoming new members and contributors
-* **Internal engagement** - engaging the community and communicating updates
-* **External engagement** - identifying and building relationships with relevant projects
+* **Awareness** - Projects which help to bring awareness to AirSwap.
+  * Awareness of the **product** - Drive user engagement with the web app.
+  * Awareness of the **protocol** - Drive new integrations.
+  * Awareness of our **community** - Welcome new members and contributors.
+* **Internal engagement** - Engage the community and communicate updates.
+* **External engagement** - Identify and build relationships with relevant projects.
 
 ## How-to
 
 ### Coordination
 
-Contributors work together on [ongoing projects](https://github.com/airswap/airswap-growth/projects/1) through [Discord](https://chat.airswap.io) channels. The delivery team meets weekly to discuss ongoing projects and tasks. Shorter meetings may also be arranged for special topics.
+Contributors work together on [ongoing projects](https://github.com/airswap/airswap-aips/issues) through [Discord](https://chat.airswap.io) channels. The delivery team meets weekly to discuss ongoing projects and tasks. Shorter meetings may also be arranged for special topics.
 
 ### Equipping
 
@@ -41,7 +41,7 @@ Contributors are typically the first contact for newcomers to the community - so
 
 Contributors are also encouraged to participate in other communities, in order to understand and identify potential partners. As an ambassador, you help to represent the AirSwap community, and as such should always behave appropriately - especially in other communities.
 
-Contributors would also need to keep up-to-date with the latest discussions and proposals in AirSwap, so that general queries can be addressed or, at least, pointed in the right direction.
+Contributors also need to keep up-to-date with the latest discussions and proposals in AirSwap, so that general queries can be addressed or, at least, pointed in the right direction.
 
 For more information, please refer to our [code of conduct](../community/code-of-conduct.md).
 
@@ -50,15 +50,15 @@ For more information, please refer to our [code of conduct](../community/code-of
 At the end of each voting cycle, Contributors allocate GIVE tokens on [Coordinape](https://coordinape.com) to reward others based on their contributions during that cycle. At the end of the cycle, rewards are paid out based on their allocation of GIVE tokens.
 
 {% hint style="info" %}
-Read more on rewards [here](../community/rewards.md)
+Read more on rewards [here](../community/rewards.md).
 {% endhint %}
 
 ### Joining
 
 Members who are interested in contributing to delivery can reach out to other Contributors in [Discord](https://chat.airswap.io). In general, Contributors to delivery are selected based on language spoken, their knowledge of AirSwap, their connections with other communities, their motivations, skills and visions.
 
-Delivery team members would be expected to read the [guides](https://about.airswap.io) to understand more about AirSwap's product and technology, and to help welcome new members into the community. Once ready, contributors can nominate new members into the circle. If two other contributors vouch for the nominee, s/he will automatically be inducted into the circle and can benefit from the circle rewards.
+Delivery team members would be expected to read the [guides](https://about.airswap.io) to understand more about AirSwap's product and technology, and to help welcome new members into the community. Once ready, contributors can nominate new members into the circle. If two other contributors vouch for the nominee, they will automatically be inducted into the circle and can benefit from the circle rewards.
 
 {% hint style="info" %}
-New members interested to try contributing can also help to create content (e.g. tutorials and guides) and be rewarded in [bounties](https://github.com/airswap/airswap-about/tree/d27062da8c952b6204d213079d222c1ffd6c96e9/bounties.md) before being nominated into the circle!
+New members interested in contributing can also help to create content (e.g. tutorials and guides) and be rewarded in [bounties](../community/bounties.md) before being nominated into the circle!
 {% endhint %}

--- a/activities/direction.md
+++ b/activities/direction.md
@@ -16,14 +16,14 @@ Contributors help to guide the direction of AirSwap by drafting AirSwap Improvem
 
 Contributors identify a relevant issue, or potential improvement for AirSwap. After initial brainstorming, the author creates a new topic on [GitHub](https://github.com/airswap/airswap-aips/issues).
 
-The structure of a proposal is as follows (See: [AIP 1](https://github.com/airswap/airswap-aips/issues/1/31)). Each proposal includes a summary, specification, rationale, and copyright.
+The structure of a proposal is as follows (See: [AIP 1](https://github.com/airswap/airswap-aips/issues/1)). Each proposal includes a summary, specification, rationale, and copyright.
 
 * **Summary** — A short (200 word) summary describing the proposal.
 * **Rationale** — Motivations, justifications, arguments for and against.
 * **Specification** — Technical specification for the proposal.
 * **Copyright** — All proposals are public domain via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-Examples of AIPs which have been voted on previously can be viewed on [Snapshot](https://snapshot.org/#/vote.airswap.eth)
+Examples of AIPs which have been voted on previously can be viewed on [Snapshot](https://snapshot.org/#/vote.airswap.eth).
 
 ## How-to
 
@@ -34,9 +34,9 @@ During the monthly cycle, contributors discuss [open issues and proposals](https
 Coordination generally takes place on two platforms:
 
 1. Brainstorming on Discord where comments happen in real-time and community members build on each other's ideas rapidly. A great way to iterate on fresh ideas.
-2. In-depth discussion here on GitHub where slower moving comments contribute to our longer term memory and feedback gets integrated directly into proposals.
+2. In-depth discussion on GitHub where slower moving comments contribute to our longer term memory and feedback gets integrated directly into proposals.
 
-At the end of the cycle, contributors come to an agreement as to which AIPs (if any) are ready to be voted on. Authors are encouraged to continue iterating on proposals if they do not feel that it is ready to go up for vote yet.
+At the end of the cycle, contributors come to an agreement as to which AIPs (if any) are ready to be voted on. Authors are encouraged to continue iterating on proposals if they do not feel that they are ready to go up for vote yet.
 
 AIPs called to vote will require a point-by-point summary of the proposal which will be put up on [Snapshot](https://snapshot.org/#/vote.airswap.eth). Authors will work with the Admins to ensure that the summaries are easily understood by the general voting community.
 
@@ -45,7 +45,7 @@ AIPs called to vote will require a point-by-point summary of the proposal which 
 At the end of each cycle, contributors allocate GIVE tokens on [Coordinape](https://coordinape.com) to reward others based on their contributions in that cycle. At the end of the cycle, AST rewards are paid out based on their allocation of GIVE tokens.
 
 {% hint style="info" %}
-Read more on rewards [here](../community/rewards.md)
+Read more on rewards [here](../community/rewards.md).
 {% endhint %}
 
 ### Joining

--- a/activities/overview.md
+++ b/activities/overview.md
@@ -10,10 +10,10 @@ AirSwap is **accessible**, **equitable**, and **transparent**. Every participant
 
 There are lots of ways to get involved in AirSwap, from generating ideas, to coordinating projects, contributing design and code, and helping to spread the word. Contributors have the flexibility of deciding how they want to contribute to AirSwap and be [rewarded ](../community/rewards.md)each round.
 
-* ****[**Vote** ](voting.md)- Stake AirSwap Tokens (AST) and vote on the future roadmap of AirSwap
-* ****[**Direct** ](direction.md)- Draft and propose new projects and protocols for the community to vote on
-* **Develop** - build new features and products which have been voted in by the community
-* ****[**Deliver** ](delivery.md)- bring community-built software to a wider audience
+* ****[**Vote** ](voting.md)- Stake AirSwap Tokens (AST) and vote on the future roadmap of AirSwap.
+* ****[**Direct** ](direction.md)- Draft and propose new projects and protocols for the community to vote on.
+* **Develop** - Build new features and products which have been voted in by the community.
+* ****[**Deliver** ](delivery.md)- Bring community-built software to a wider audience.
 
 {% hint style="info" %}
 Join our [Discord ](https://discord.gg/BQaJCgmhD7)to find out more about how you can be a part of our mission!

--- a/activities/overview.md
+++ b/activities/overview.md
@@ -8,13 +8,13 @@ AirSwap itself is a community asset owned by its token (AST) holders, operating 
 
 AirSwap is **accessible**, **equitable**, and **transparent**. Every participant and contributor is treated fairly and rewarded consistently. All opportunities are inclusive and available. Decisions are made in the open and contributions are open source. New information is continuously and actively shared throughout.
 
-There are lots of ways to get involved in AirSwap, from generating ideas, to coordinating projects, contributing design and code, and helping to spread the word. Contributors have the flexibility of deciding how they want to contribute to AirSwap and be [rewarded ](../community/rewards.md)each round.
+There are lots of ways to get involved in AirSwap, from generating ideas, to coordinating projects, contributing design and code, and helping to spread the word. Contributors have the flexibility of deciding how they want to contribute to AirSwap and be [rewarded](../community/rewards.md) each round.
 
-* ****[**Vote** ](voting.md)- Stake AirSwap Tokens (AST) and vote on the future roadmap of AirSwap.
-* ****[**Direct** ](direction.md)- Draft and propose new projects and protocols for the community to vote on.
+* [**Vote**](voting.md) - Stake AirSwap Tokens (AST) and vote on the future roadmap of AirSwap.
+* [**Direct**](direction.md) - Draft and propose new projects and protocols for the community to vote on.
 * **Develop** - Build new features and products which have been voted in by the community.
-* ****[**Deliver** ](delivery.md)- Bring community-built software to a wider audience.
+* [**Deliver**](delivery.md) - Bring community-built software to a wider audience.
 
 {% hint style="info" %}
-Join our [Discord ](https://discord.gg/BQaJCgmhD7)to find out more about how you can be a part of our mission!
+Join our [Discord](https://discord.gg/BQaJCgmhD7) to find out more about how you can be a part of our mission!
 {% endhint %}

--- a/activities/voting.md
+++ b/activities/voting.md
@@ -39,7 +39,7 @@ Reading up and informing yourself on each proposal is an important part of the p
 Voting cycles take place every month, where a number of AIPs will be voted on concurrently. You must vote on all proposals in order to earn the maximum number of points. To browse and participate in votes, visit the [AirSwap governance portal](https://activate.codefi.network/staking/airswap/governance) on Codefi Activate when voting is live. Note that voting is performed off-chain and does not cost gas (ETH).
 
 {% hint style="info" %}
-You can check out when the next voting cycle will begin on this [dashboard](https://dune.xyz/agrimony/airswap\_3)
+You can check out when the next voting cycle will begin on this [dashboard](https://dune.xyz/agrimony/airswap\_3).
 {% endhint %}
 
 ### Claiming
@@ -55,5 +55,5 @@ Notes on points:
 The number of points enables you to claim a certain percentage of the rewards pool tokens.
 
 {% hint style="info" %}
-Learn more about claiming voting rewards [here](../community/rewards.md#voting-rewards)
+Learn more about claiming voting rewards [here](../community/rewards.md#voting-rewards).
 {% endhint %}

--- a/community/rewards.md
+++ b/community/rewards.md
@@ -21,7 +21,7 @@ The formula results in rewards being paid out on a smooth curve based on the num
 ⚠ Note that fees are continuously streaming into the community pool and participants are continuously claiming tokens. Due to the dynamic nature of this process, slippage on claims is possible.
 
 {% hint style="info" %}
-You can [see the tokens in the pool](https://app.zerion.io/0x7296333e1615721f4Bd9Df1a3070537484A50CF8/overview) and [calculate potential rewards using this dashboard](https://dune.xyz/agrimony/airswap\_3)
+You can [see the tokens in the pool](https://app.zerion.io/0x7296333e1615721f4Bd9Df1a3070537484A50CF8/overview) and [calculate potential rewards using this dashboard](https://dune.xyz/agrimony/airswap\_3).
 {% endhint %}
 
 ## Circle Funding
@@ -42,7 +42,7 @@ _Base funding level is subject to monthly review and can change._
 
 ## Circle Allocation
 
-After each monthly cycle, The [Coordinape ](https://coordinape.com)circle will open for all contributors to reward their co-workers with GIVE tokens. Contributors will start with 100 GIVE tokens. These GIVE tokens are used to reward team members with according to their impact in the circle during the current cycle.
+After each monthly cycle, the [Coordinape ](https://coordinape.com)circle will open for all contributors to reward their co-workers with GIVE tokens. Contributors will start with 100 GIVE tokens. These GIVE tokens are used to reward team members with according to their impact in the circle during the current cycle.
 
 After the allocation period is complete, any GIVE tokens not distributed will be burnt (there is no use holding GIVE tokens for yourself!). Individual contributors will be rewarded from the base/bonus circle funds proportionally to their GIVE allocations received.
 

--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -34,7 +34,7 @@ Voters are rewarded with points based on the amount staked. Points can be used t
 
 ### How do I stake on AirSwap?
 
-You can stake your AST on the [Codefi Activate platform](https://activate.codefi.network/staking/airswap/governance)
+You can stake your AST on the [Codefi Activate platform](https://activate.codefi.network/staking/airswap/governance).
 
 ### What are the rules of staking?
 

--- a/technology/last-look.md
+++ b/technology/last-look.md
@@ -4,9 +4,9 @@ AirSwap Last Look \(LL\) is a protocol used by market makers to stream quotes to
 
 **Protocol Features**
 
-* Takers can see quotes without connecting a wallet, and quotes update in realtime
-* Takers don't submit or spend gas on transactions, the maker does instead
-* Better prices from makers since their prices are not locked into an expiry
+* Takers can see quotes without connecting a wallet, and quotes update in realtime.
+* Takers don't submit or spend gas on transactions, the maker does instead.
+* Better prices from makers since their prices are not locked into an expiry.
 
 There is a possibility the maker declines the order because the market has moved, but they're generally amenable to small fluctuations to maintain a good trading relationship with the taker.
 


### PR DESCRIPTION
This PR fixes additional broken links that I found as I was reading through the AirSwap About pages, as well as updates semantics and basic styling for the bulleted lists and quotes to keep it more consistent throughout.