### PR TITLE
Textual errors/correction update

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ AirSwap launched with the AirSwap Token (AST) [October 10th, 2017](https://mediu
 
 ### Governance
 
-To generate new ideas and directions for the project and cultivate transparency, we use a process called [AirSwap Improvement Proposals (AIP)](community/proposals.md). AIPs give the community a way to finalize proposals to core contributors on an ongoing basis. For more information see [AIP 1](https://github.com/airswap/airswap-aips/issues/1) and check out [all active proposals](https://github.com/airswap/aips). This is how the community captures, selects, and prioritizes new projects.
+To generate new ideas and directions for the project and cultivate transparency, we use a process called [AirSwap Improvement Proposals (AIP)](community/proposals.md). AIPs give the community a way to vote on and finalize proposals on an ongoing basis. For more information see [AIP 1](https://github.com/airswap/airswap-aips/issues/1) and check out [all active proposals](https://github.com/airswap/aips). This is how the community captures, selects, and prioritizes new projects.
 
 Each AIP is ratified by calling it to vote and being accepted by the token holder community. Voting is held on [Codefi Activate](https://activate.codefi.network/staking/airswap/governance). Once votes are completed, proposals are considered finalized and placed in a backlog for selection by contributors. Based on requirements and feasibility, contributors may accept the proposal for prioritization and implementation.
 

--- a/community/earning.md
+++ b/community/earning.md
@@ -65,7 +65,7 @@ If you have not contributed for the month, remember to **Opt-out** of receiving 
 
 ## Allocate accurately
 
-[Coordinape](https://coordinape.com) circles will open 1st - 6th of each month for all contributors to reward their co-workers with GIVE tokens. Contributors will start with 100 GIVE tokens. These GIVE tokens are used to reward team members with according to their impact in the circle during the current cycle.
+[Coordinape](https://coordinape.com) circles will open 1st - 6th of each month for all contributors to reward their co-workers with GIVE tokens. Contributors will start with 100 GIVE tokens. These GIVE tokens are used to reward team members according to their impact in the circle during the current cycle.
 
 After the allocation period is complete, any GIVE tokens not distributed will be burnt (there is no use holding GIVE tokens for yourself!). Individual contributors will be rewarded from the circle funds proportionally to their GIVE allocations received.
 

--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -9,16 +9,16 @@ AirSwap has a number of benefits.
 - Non-custodial. Unlike a centralized exchange, AirSwap does not take custody of funds.
 - No sign-ups. AirSwap does not require users to sign up and does not collect sensitive data.
 - No slippage. On AirSwap, prices are exact so the price you see is the price you get.
-- Intuitive. AirSwap is designed with UX as a top priorities.
+- Intuitive. AirSwap is designed with UX as a top priority.
 - Secure. AirSwap was rated the #1 safest Ethereum decentralized exchange.
 
 Learn more about AirSwap's benefits in the blog post [Why AirSwap?](https://medium.com/fluidity/why-airswap-62ff8b4ee81d)
 
-### How is AirSwap different than Uniswap?
+### How is AirSwap different from Uniswap?
 
 Uniswap is a "peer-to-contract" automated market maker (AMM) that runs fully on-chain. AirSwap is a peer-to-peer network combining off-chain negotiation and on-chain settlement by atomic swap.
 
-There are benefits to each. With AirSwap there is no price slippage and trades are unlimited size. The trade-off is that it's easier for everyday users to provide liquidity to Uniswap. However, a successful outcome for RFQ is a few high quality liquidity providers covering a variety of digital assets, so AirSwap does not require the same number of liquidity providers to be successful.
+There are benefits to each. With AirSwap there is no price slippage and trades are unlimited in size. The trade-off is that it's easier for everyday users to provide liquidity to Uniswap. However, a successful outcome for RFQ is a few high quality liquidity providers covering a variety of digital assets, so AirSwap does not require the same number of liquidity providers to be successful.
 
 ### Is AirSwap available on other chains?
 

--- a/technology/glossary.md
+++ b/technology/glossary.md
@@ -24,7 +24,7 @@ Digital tokens can represent both purely digital assets and real-world assets.
 
 # Slippage and Front-running
 
-**Slippage occurs when** a trade executes differently than the expected price. This is caused by other orders being executed ahead of the submitted order. [Slippage](https://www.investopedia.com/terms/s/slippage.asp) can be to either the detriment and benefit to a trader, depending on which direction it occurs. Slippage is commonplace in all continuous markets, that is, a market where the previous order impacts the price of the next. Slippage is avoidable in P2P systems, which are not continuous.
+**Slippage occurs when** a trade executes differently than the expected price. This is caused by other orders being executed ahead of the submitted order. [Slippage](https://www.investopedia.com/terms/s/slippage.asp) can be to either the detriment or benefit of a trader, depending on which direction it occurs. Slippage is commonplace in all continuous markets, that is, a market where the previous order impacts the price of the next. Slippage is avoidable in P2P systems, which are not continuous.
 
 **Front-running occurs when** a third-party sees an order before it is executed and takes advantage of this information to submit an order of its own to be executed first. [Front-running](https://www.investopedia.com/terms/f/frontrunning.asp) is prohibited in traditional markets. In the land of pseudonymous public ledgers, front-running is commonplace and a fundamental part of on-chain continuous markets through the practice of [MEV](https://ethereum.org/en/developers/docs/mev/). Front-running can also be avoided in P2P systems because they are not continuous.
 

--- a/technology/makers.md
+++ b/technology/makers.md
@@ -14,7 +14,7 @@ For the RFQ protocol, a server is always the **signer** and the client is always
 
 ## HTTP vs WebSocket
 
-If a URL is HTTPS, it is implied that the server supports the latest RFQ protocol at that endpoint. If a URL is WebSocket (`wss`) then the server communicates its supported protocols upon connnection. See the `initialize` method of the [Request for Quote](protocols.md#rfq) and [Last Look](protocols.md#last-look) protocols for details. WebSocket servers can support both RFQ and Last Look protocols.
+If a URL is HTTPS, it implies that the server supports the latest RFQ protocol at that endpoint. If a URL is WebSocket (`wss`) then the server communicates its supported protocols upon connnection. See the `initialize` method of the [Request for Quote](protocols.md#rfq) and [Last Look](protocols.md#last-look) protocols for details. WebSocket servers can support both RFQ and Last Look protocols.
 
 ## Getting Started
 
@@ -28,7 +28,7 @@ Getting started is as easy as standing up a JSON-RPC web server and adding its U
 
 When signing orders in RFQ, a protocol fee (in basis points) is [hashed into the signature](broken-reference) and verified during settlement. The value of this parameter must match its current value of `protocolFeeLight` on the [Swap](deployments.md) contract. The amount is transferred from the `signerWallet` address upon settlement.
 
-100% of protocol fees go toward AirSwap governance participants and project contributors.
+100% of protocol fees go toward rewarding AirSwap governance participants and project contributors.
 
 ## Handling Errors
 


### PR DESCRIPTION
Page: Community 
Section: https://about.airswap.io/#governance
Error: AIPs give the community a way to finalize proposals to core contributors on an ongoing basis.
Correction: AIPs give the community a way to vote on and finalize proposals.

Page: Questions
Section: https://about.airswap.io/frequently-asked-questions#protocols
Error: AirSwap is designed with UX as a top priorities.
Correction: replace 'priorities' with 'priority'.

Page: Questions
Section: https://about.airswap.io/frequently-asked-questions#protocols
Error: How is AirSwap different than Uniswap? 
Correction: replace 'than' with 'from'.

Page: Questions
Section: https://about.airswap.io/frequently-asked-questions#protocols
Error: With AirSwap there is no price slippage and trades are unlimited size.
Correction: add 'of' after 'are' or add 'in' before 'size'.

Page: Rewards and Tips
Section: https://about.airswap.io/community/earning#allocate-accurately
Error: These GIVE tokens are used to reward team members with according to their impact in the circle
Correction: remove 'with'.

Page: Makers 
Section: https://about.airswap.io/technology/makers#http-vs-websocket
Error: If a URL is HTTPS, it is implied that the server supports the latest RFQ protocol at that endpoint.
Correction: replace 'is implied' with 'implies'.

Page: Makers 
Section: https://about.airswap.io/technology/makers#protocol-fees
Error: 100% of protocol fees go toward AirSwap governance participants and project contributors. 
Correction: add ' rewarding' after 'toward'.

Page: Glossary 
Section: https://about.airswap.io/technology/glossary#slippage-and-front-running 
Error: Slippage can be to either the detriment and benefit to a trader
Correction: replace 'to either the' with 'of either'. Replace 'and' with 'or'. 

